### PR TITLE
Potential fix for code scanning alert no. 14: Information exposure through an exception

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -484,7 +484,8 @@ async def generate(req: GenerateRequest, _auth_dep=Depends(_auth), _rate_dep=Dep
             "logs": startup_logs,
         }
     except Exception as exc:
-        return {"status": "error", "error": str(exc)}
+        LOGGER.exception("Unexpected error in /generate endpoint")
+        return {"status": "error", "error": "Internal server error"}
 
 
 # ── Audit Export Endpoints ───────────────────────────────────────────────────


### PR DESCRIPTION
Potential fix for [https://github.com/JRM-FusionAL/FusionAL/security/code-scanning/14](https://github.com/JRM-FusionAL/FusionAL/security/code-scanning/14)

To fix this without changing intended functionality, keep the same error response shape/status semantics but stop returning raw exception text to users.

Best approach in `core/main.py` at the `generate` handler:

- Replace `return {"status": "error", "error": str(exc)}` with a generic message such as `"Internal server error"`.
- Log the caught exception server-side with stack trace using `LOGGER.exception(...)` inside the `except` block.
- Since `logging` and `LOGGER` are already present, no new imports are required.

This preserves API behavior (`status: error`) while preventing leakage of internal exception details to external callers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
