### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/core/common/security.py
+++ b/core/common/security.py
@@ -168,7 +168,7 @@ def _build_log_payload(
         "duration_ms": round(duration_ms, 2),
         "client_ip": client_ip,
         "user_agent": user_agent,
-        "headers": redacted_headers,
+        "header_names": sorted(redacted_headers.keys()),
     }
     payload.update(_get_trace_context())
     return payload


### PR DESCRIPTION
Potential fix for [https://github.com/JRM-FusionAL/FusionAL/security/code-scanning/1](https://github.com/JRM-FusionAL/FusionAL/security/code-scanning/1)

General fix: stop logging sensitive request content (especially header values), and keep observability by logging only minimal, non-sensitive metadata.

Best fix in this snippet: in `core/common/security.py`, inside `_build_log_payload`, replace `"headers": redacted_headers` with a safe representation such as `"header_names": sorted(redacted_headers.keys())`. This preserves operational debugging value (which headers were present) without storing secret-bearing values, redacted or otherwise. No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
