### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -433,7 +433,7 @@ async def generate(req: GenerateRequest, _auth_dep=Depends(_auth), _rate_dep=Dep
         tools = _extract_tools_from_code(generated_code)
         port = _find_available_port(8200, 8299)
 
-        tmpdir = tempfile.mkdtemp(prefix=f"{server_name}-")
+        tmpdir = tempfile.mkdtemp(prefix="generated-server-")
         script_path = os.path.join(tmpdir, "generated_server.py")
         with open(script_path, "w", encoding="utf-8") as f:
             f.write(generated_code)


### PR DESCRIPTION
Potential fix for [https://github.com/JRM-FusionAL/FusionAL/security/code-scanning/3](https://github.com/JRM-FusionAL/FusionAL/security/code-scanning/3)

Best general fix: never pass user-derived values into filesystem path-building APIs unless you enforce a strict allowlist and root confinement check. Here, the cleanest fix is to use a constant prefix for `tempfile.mkdtemp` and keep `server_name` only for logical metadata.

In `core/main.py`, update the `mkdtemp` call around line 436:
- Replace `prefix=f"{server_name}-"` with a fixed trusted prefix such as `"generated-server-"`.
- No import changes are required.
- Functionality is preserved (still creates unique temp directory); only directory naming changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
