### PR TITLE
chore(deps): bump mcp from 1.26.0 to 1.27.1

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -6,7 +6,7 @@ python-dotenv==1.2.2
 requests==2.33.1
 anthropic==0.104.1
 redis==7.4.0
-mcp[cli]==1.26.0
+mcp[cli]==1.27.1
 
 # Tracing (OpenTelemetry)
 opentelemetry-sdk>=1.42.1


### PR DESCRIPTION
Bumps mcp[cli] from 1.26.0 to 1.27.1 in core/requirements.txt (canonical dep file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**What**  
Bumped the `mcp[cli]` dependency to `1.27.1` to keep the core requirements up to date.

**Changes**  
- `core/requirements.txt` — updated `mcp[cli]` from `1.26.0` to `1.27.1`.

**Dependencies**  
- No new packages, env vars, or config were added.
- Existing package updated: `mcp[cli]`

**Testing**  
- Verify `core/requirements.txt` now pins `mcp[cli]==1.27.1`.
- Reinstall dependencies and run the project’s usual smoke/test suite to confirm compatibility.

**Contributors**  
| Author | Lines added | Lines removed |
|---|---:|---:|
| Unknown | 1 | 1 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->