### PR TITLE
chore: update dependencies

### DIFF
--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.138.0
 uvicorn[standard]==0.49.0
 pydantic==2.13.4
+pydantic-core==2.46.4
 openai==2.43.0
 python-dotenv==1.2.2
 requests==2.34.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anthropic==0.112.0
-anyio==4.14.0
+anyio==4.14.1
 asgiref==3.11.1
 attrs==26.1.0
 boolean.py==5.0
@@ -9,7 +9,7 @@ CacheControl==0.14.4
 certifi==2026.6.17
 cffi==2.0.0
 charset-normalizer==3.4.7
-click==8.4.1
+click==8.4.2
 cryptography==49.0.0
 cyclonedx-python-lib==11.11.0
 defusedxml==0.7.1
@@ -56,7 +56,7 @@ pycparser==3.0
 pycryptodomex==3.23.0
 pydantic==2.13.4
 pydantic-settings==2.14.2
-pydantic_core==2.46.4
+pydantic_core==2.47.0
 Pygments==2.20.0
 PyJWT==2.13.0
 pyparsing==3.3.2
@@ -71,12 +71,12 @@ rpds-py==2026.5.1
 shellingham==1.5.4
 sniffio==1.3.1
 sortedcontainers==2.4.0
-sse-starlette==3.4.4
+sse-starlette==3.4.5
 starlette==1.3.1
 tomli==2.4.1
 tomli_w==1.2.0
 tqdm==4.68.3
-typer==0.26.7
+typer==0.26.8
 typing-inspection==0.4.2
 typing_extensions==4.15.0
 urllib3==2.7.0
@@ -85,4 +85,4 @@ uvloop==0.22.1
 watchfiles==1.2.0
 websockets==16.0
 wheel==0.47.0
-wrapt==2.2.1
+wrapt==2.2.2


### PR DESCRIPTION
This PR updates dependencies to their latest versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What
Updates pinned project dependencies to the latest patch versions.

## Changes
- `requirements.txt` — bumps several dependency pins for patch-level updates:
  - `anyio` `4.14.0` → `4.14.1`
  - `click` `8.4.1` → `8.4.2`
  - `pydantic_core` `2.46.4` → `2.47.0`
  - `sse-starlette` `3.4.4` → `3.4.5`
  - `typer` `0.26.7` → `0.26.8`
  - `wrapt` `2.2.1` → `2.2.2`
- `core/requirements.txt` — adds an explicit `pydantic-core==2.46.4` pin after the existing `pydantic==2.13.4` entry.

## Dependencies
- No new packages or configuration added; dependency versions are updated (plus an explicit `pydantic-core==2.46.4` pin in `core/requirements.txt`).

## Testing
- Reinstall dependencies using the updated requirements files and confirm installation succeeds.
- Run the existing test suite (or at minimum, a smoke test) using the freshly installed dependencies.

## Contributors
| author | lines added | lines removed |
|---|---:|---:|
| not provided | 7 | 6 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->