### PR TITLE
chore: update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ pycparser==3.0
 pycryptodomex==3.23.0
 pydantic==2.13.4
 pydantic-settings==2.14.2
-pydantic_core==2.47.0
+pydantic-core==2.46.4
 Pygments==2.20.0
 PyJWT==2.13.0
 pyparsing==3.3.2


### PR DESCRIPTION
This PR updates dependencies to their latest versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What
Pin dependency versions by adding runtime/tooling manifests and aligning `pydantic-core` with `pydantic`.

## Changes
- Added `requirements.txt` — full dependency manifest; pins `pydantic==2.13.4` and `pydantic-core==2.46.4` plus required runtime, OpenTelemetry, and tooling packages.
- Added `core/requirements.txt` — minimal “core” dependency set (includes `pydantic`/`pydantic-core` alignment and `mcp[cli]`).
- Added example manifests:
  - `examples/dice-roller/requirements.txt` — `mcp[cli]>=1.26.0`
  - `examples/file-utils/requirements.txt` — `mcp[cli]>=1.26.0`
  - `examples/weather-api/requirements.txt` — `mcp[cli]>=1.26.0`, `requests>=2.33.0`
- Added `.env.example` — documents required configuration (API keys, CORS, rate limiting, logging, policy profile, MCP server URL, Notion poller settings).

## Dependencies
- New/declared packages/config:
  - `pydantic-core==2.46.4` to match `pydantic==2.13.4` (in both `requirements.txt` and `core/requirements.txt`)
  - `opentelemetry-*` (pinned in `requirements.txt`; minimums in `core/requirements.txt`)
  - `fastapi==0.138.2`, `uvicorn==0.49.0`
  - `openai==2.44.0`, `anthropic==0.113.0`
- New environment/config template:
  - `.env.example` defines variables such as `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `API_KEY`, `ALLOWED_ORIGINS`, `RATE_LIMIT_REQUESTS`, `RATE_LIMIT_WINDOW_SECONDS`, `LOG_LEVEL`, `FUSIONAL_POLICY_PROFILE`, `MCP_SERVER_URL`, `NOTION_TOKEN`, etc.

## Testing
- Install dependencies from `requirements.txt`.
- Run `pytest` (and any repo lint/type steps such as `ruff` / `mypy` if used in CI).
- Verify imports/startup for components that use `pydantic` models to confirm the `pydantic-core` pin is compatible.

## Contributors
| Author | Lines added | Lines removed |
|---|---:|---:|
| `Jonathan Melton` | 161 | 0 |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->