### PR TITLE
chore: pin setuptools>=83.0.0, fix stale dependency docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,17 +318,23 @@ Registry entry structure:
 
 | Package | Version | Purpose |
 |---------|---------|--------|
-| `fastapi` | 0.143.0 | Web framework |
-| `uvicorn[standard]` | 0.45.0 | ASGI server |
-| `pydantic` | 2.15.0 | Request/response models |
-| `anthropic` | 0.96.0 | Claude API client |
-| `openai` | 2.32.0 | OpenAI fallback |
-| `mcp[cli]` | 1.27.1 | MCP server framework |
-| `redis` | 7.4.0 | Rate limit store |
-| `opentelemetry-*` | ≥1.40.0 | Distributed tracing |
+| `fastapi` | 0.139.0 | Web framework |
+| `uvicorn[standard]` | 0.51.0 | ASGI server |
+| `pydantic` | 2.13.4 | Request/response models |
+| `anthropic` | 0.116.0 | Claude API client |
+| `openai` | 2.44.0 | OpenAI fallback |
+| `mcp[cli]` | 1.28.1 | MCP server framework |
+| `redis` | 8.0.1 | Rate limit store |
+| `opentelemetry-*` | ≥1.43.0 | Distributed tracing |
 
-Always pin `setuptools ≥82.0.1`, `jaraco.context ≥6.1.2`, `wheel ≥0.46.3` to avoid
-known CVEs in transitive deps.
+Note: this table is a point-in-time snapshot. Dependabot and the daily dependency-update
+bot land patch/minor bumps continuously, so treat `core/requirements.txt` as the source
+of truth and this table as a rough guide, not a live mirror.
+
+Always pin `setuptools ≥83.0.0` (fixes CVE-2026-59890, a setuptools-native sdist
+MANIFEST.in exclusion bypass — the older ≥82.0.1 floor only covered the vendored
+jaraco.context/wheel CVEs, not this one), `jaraco.context ≥6.1.2`, `wheel ≥0.47.0` to
+avoid known CVEs in transitive deps.
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,6 +85,7 @@ requests-oauthlib==2.0.0
 rich==15.0.0
 rpds-py==2026.6.3
 ruff==0.15.20
+setuptools>=83.0.0
 sgmllib3k==1.0.0
 shellingham==1.5.4
 six==1.17.0


### PR DESCRIPTION
## Summary

From a scheduled dependency audit across all connected repos. This repo already has Dependabot + a daily automated dependency-update bot handling nearly every version bump (fastapi, openai, mcp, redis, opentelemetry, etc. all have open PRs already), so this PR only covers the two gaps that automation doesn't touch:

- **`requirements.txt`**: add an explicit `setuptools>=83.0.0` pin. CLAUDE.md documented a `>=82.0.1` floor, but `requirements.txt` never actually pinned setuptools directly — it was inherited transitively. 82.0.1 also only covers the CVEs in setuptools' *vendored* copies of jaraco.context/wheel; the setuptools-native CVE-2026-59890 (sdist `MANIFEST.in` exclusion bypass via Unicode normalization, can leak files meant to be excluded from a published package) needs `>=83.0.0`.
- **`CLAUDE.md`**: the "Key Dependencies" table was badly stale (e.g. listed fastapi 0.143.0 / anthropic 0.96.0 / mcp 1.27.1 against actual pins of 0.139.0 / 0.116.0 / 1.28.1). Synced it to current `requirements.txt` and added a note that the table is a snapshot, not a live mirror, since the update bots will keep drifting it. Also corrected the setuptools floor to match the CVE fix above.

## Test plan

- [ ] `pip install -r requirements.txt` resolves cleanly with the new setuptools pin
- [ ] CI passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfqGXcGGJGrwxErnzooyAN)_