### PR TITLE
Fix starlette CVE exposure in core, bump gateway/root deps

### DIFF
--- a/core/common/rate_limit_presets.py
+++ b/core/common/rate_limit_presets.py
@@ -261,7 +261,6 @@ def configure_error_budget_tracking(
 
     @app.middleware("http")
     async def _error_budget_middleware(request: "Request", call_next: object):
-        from fastapi import Response  # local import to avoid circular deps
 
         response: Response = await call_next(request)  # type: ignore[misc]
         is_error = response.status_code >= 500

--- a/core/common/test_audit.py
+++ b/core/common/test_audit.py
@@ -3,9 +3,8 @@
 import csv
 import io
 import json
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 
-import pytest
 
 from audit import (
     AuditRecord,

--- a/core/common/test_rate_limit_presets.py
+++ b/core/common/test_rate_limit_presets.py
@@ -10,7 +10,6 @@ Covers:
 """
 
 import logging
-import time
 
 import pytest
 from fastapi import FastAPI

--- a/core/main.py
+++ b/core/main.py
@@ -20,8 +20,7 @@ import tempfile
 import time
 from datetime import datetime
 from pathlib import Path
-from contextlib import asynccontextmanager
-from typing import List, Optional
+from typing import Optional
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
@@ -76,7 +75,7 @@ except ImportError:
     _AUDIT_ENABLED = False
 
 # --- MCP transport + aggregating proxy ---
-from .mcp_transport import mcp, register_downstream_tools, set_audit_hook
+from .mcp_transport import mcp, set_audit_hook  # noqa: E402
 
 # Wire the audit hook so proxied tool calls are recorded
 if _AUDIT_ENABLED:
@@ -88,7 +87,7 @@ try:
 except Exception:
     run_in_docker = None
 
-from .ai_agent import generate_python_from_claude, generate_python_from_openai
+from .ai_agent import generate_python_from_claude, generate_python_from_openai  # noqa: E402
 PORT = int(os.getenv("PORT", "8009"))
 LOGGER = logging.getLogger("fusional.main")
 
@@ -110,7 +109,7 @@ if _TRACING_IMPORTABLE:
 mcp.settings.streamable_http_path = "/"
 mcp_app = mcp.streamable_http_app()
 app.mount("/mcp", mcp_app)
-from fastapi.staticfiles import StaticFiles
+from fastapi.staticfiles import StaticFiles  # noqa: E402
 _wk_dir = os.environ.get("WELL_KNOWN_DIR", os.path.join(os.path.dirname(__file__), "..", "well-known"))
 if os.path.isdir(_wk_dir):
     app.mount("/.well-known", StaticFiles(directory=_wk_dir), name="well-known")
@@ -476,7 +475,7 @@ async def generate(req: GenerateRequest, _auth_dep=Depends(_auth), _rate_dep=Dep
             "provider": provider_used,
             "logs": startup_logs,
         }
-    except Exception as exc:
+    except Exception:
         LOGGER.exception("Unexpected error in /generate endpoint")
         return {"status": "error", "error": "Internal server error"}
 

--- a/core/mcp_transport.py
+++ b/core/mcp_transport.py
@@ -18,7 +18,7 @@ import logging
 import time
 from typing import Any
 
-from pydantic import ConfigDict, create_model
+from pydantic import ConfigDict
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.tools.base import Tool

--- a/core/quick_test.py
+++ b/core/quick_test.py
@@ -1,6 +1,5 @@
 """Quick test of FusionAL AI generation"""
 from ai_agent import generate_mcp_project
-import json
 
 print("🚀 Testing FusionAL AI Generation...\n")
 
@@ -14,7 +13,7 @@ try:
     
     print("✅ Generation successful!")
     print(f"\n📁 Output directory: {result['out_dir']}")
-    print(f"\n📝 Generated files:")
+    print("\n📝 Generated files:")
     for file in result['files']:
         print(f"  - {file}")
     

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -1,15 +1,21 @@
-fastapi==0.138.0
-uvicorn[standard]==0.49.0
+fastapi==0.139.2
+starlette>=1.3.1
+uvicorn[standard]==0.51.0
 pydantic==2.13.4
 pydantic-core==2.46.4
-openai==2.43.0
+openai==2.47.0
 python-dotenv==1.2.2
 requests==2.34.2
-anthropic==0.111.0
-redis==8.0.0
-mcp[cli]==1.28.0
+anthropic==0.118.0
+redis==8.0.1
+mcp[cli]==1.28.1
 
 # Tracing (OpenTelemetry)
 opentelemetry-sdk>=1.42.1
 opentelemetry-instrumentation-fastapi>=0.63b1
 opentelemetry-exporter-otlp-proto-http>=1.42.1
+
+# Pinned to avoid known CVEs in transitive deps
+setuptools>=83.0.0
+jaraco.context>=6.1.2
+wheel>=0.47.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 aiosqlite==0.22.1
 annotated-doc==0.0.4
 annotated-types==0.7.0
-anthropic==0.116.0
+anthropic==0.118.0
 anyio==4.14.1
 asgiref==3.11.1
 ast_serialize==0.6.0
@@ -20,7 +20,7 @@ defusedxml==0.7.1
 distro==1.9.0
 dnspython==2.8.0
 docstring_parser==0.18.0
-fastapi==0.139.0
+fastapi==0.139.2
 feedparser==6.0.12
 filelock==3.29.7
 googleapis-common-protos==1.75.0
@@ -46,7 +46,7 @@ mdurl==0.1.2
 mypy==2.2.0
 mypy_extensions==1.1.0
 oauthlib==3.3.1
-openai==2.44.0
+openai==2.47.0
 opentelemetry-api==1.43.0
 opentelemetry-exporter-otlp-proto-common==1.43.0
 opentelemetry-exporter-otlp-proto-http==1.43.0


### PR DESCRIPTION
## Summary
- `core/requirements.txt` had no explicit `starlette` pin, leaving it exposed to CVE-2026-48710 (Host-header auth bypass) depending on whatever version fastapi's own `>=0.46.0` floor resolved at install time. Adds `starlette>=1.3.1`, matching the safe pin already present in the root `requirements.txt`.
- Bumps `fastapi`, `uvicorn`, `openai`, `anthropic`, `redis`, and `mcp[cli]` to current patched versions in `core/requirements.txt`.
- Adds `setuptools>=83.0.0`, `jaraco.context>=6.1.2`, `wheel>=0.47.0` pins to `core/requirements.txt` — this repo's own CLAUDE.md documents these as required to avoid known transitive CVEs, but they were missing from every requirements file in the repo.
- Bumps `fastapi`/`anthropic`/`openai` in the root `requirements.txt` to match.

Found by a scheduled dependency audit across all connected repos. This is the highest-priority fix of the batch since it's the security/policy gateway.

## Test plan
- [x] `pip install --dry-run -r core/requirements.txt` resolves cleanly with no conflicts
- [ ] Root `requirements.txt` has a pre-existing, unrelated `pydantic`/`pydantic_core` version conflict (present before this change, not introduced by it) — flagging for a follow-up, left untouched here
- [ ] Verify installed `starlette` version on the live t3610 deployment (`pip show starlette`) once this merges and is redeployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PNN3U7Mjk4Vd2pgXuYpQ6E

---
_Generated by [Claude Code](https://claude.ai/code/session_01PNN3U7Mjk4Vd2pgXuYpQ6E)_